### PR TITLE
Added flags for compiler.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 CC      ?= c99
-CFLAGS  ?= -O3
+CFLAGS  ?= -O3 -std=c99
 HEADERS ?= -DNCURSESW_INCLUDE_H="<ncursesw/curses.h>"
 LIBPATH ?=
 DESTDIR ?= /usr/local
@@ -8,7 +8,7 @@ DESTDIR ?= /usr/local
 all: mtm
 
 mtm: tmt.c mtm.c
-	$(CC) -o $@ $(HEADERS) tmt.c mtm.c $(LIBPATH) -lncursesw -lutil
+	$(CC) $(CFLAGS) -o $@ $(HEADERS) tmt.c mtm.c $(LIBPATH) -lncursesw -lutil
 
 install: mtm
 	cp mtm $(DESTDIR)/bin


### PR DESCRIPTION
Hi,

Great program!
I tried to compile it on my box (running Debian stable) and had several errors 

``` 
tmt.c: In function ‘dirtylines’:
tmt.c:85:5: error: ‘for’ loop initial declarations are only allowed in C99 or C11 mode
     for (size_t i = s; i < e && i < vt->screen.nline; i++)
     ^
tmt.c:85:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code

... more stuff like the above
```

This is my `gcc`  info in case it can help.

```

Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/4.9/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 4.9.2-10' --with-bugurl=file:///usr/share/d
oc/gcc-4.9/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suf
fix=-4.9 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enabl
e-threads=posix --with-gxx-include-dir=/usr/include/c++/4.9 --libdir=/usr/lib --enable-nls --with-sysroot=
/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --d
isable-vtable-verify --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --e
nable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.9-amd64/jre --enable-java-home --with-jvm-r
oot-dir=/usr/lib/jvm/java-1.5.0-gcj-4.9-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.9-a
md64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-
multiarch --with-arch-32=i586 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tu
ne=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linu
x-gnu
Thread model: posix
gcc version 4.9.2 (Debian 4.9.2-10)
```

So I made a small change in the `Makefile`. Would that be ok?



