### PR TITLE
Makefile: remove config.h when cleaning, and change DESTDIR to PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS    ?= -O3 -std=c99 -Wall -Wextra -pedantic
 FEATURES  ?= -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE -D_XOPEN_SOURCE_EXTENDED
 HEADERS   ?=
 LIBPATH   ?=
-DESTDIR   ?= /usr/local
+PREFIX    ?= /usr/local
 CURSESLIB ?= ncursesw
 LIBS      ?= -l$(CURSESLIB) -lutil
 
@@ -16,8 +16,10 @@ config.h: config.def.h
 	cp -i config.def.h config.h
 
 install: mtm
-	cp mtm $(DESTDIR)/bin
-	cp mtm.1 $(DESTDIR)/share/man/man1
+	mkdir -p $(DESTDIR)$(PREFIX)/bin
+	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
+	cp mtm $(DESTDIR)$(PREFIX)/bin
+	cp mtm.1 $(DESTDIR)$(PREFIX)/share/man/man1
 
 install-terminfo: mtm.ti
 	tic -s -x mtm.ti

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ install-terminfo: mtm.ti
 	tic -s -x mtm.ti
 
 clean:
-	rm -f *.o mtm
+	rm -f *.o mtm config.h


### PR DESCRIPTION
I think it's good to remove also config.h when doing `make clean` to achieve clean git repository

Also i've changed DESTDIR to PREFIX and added mkdirs to create directories, it's useful for packaging.