### PR TITLE
Fix color names in manual

### DIFF
--- a/mtm.1
+++ b/mtm.1
@@ -53,15 +53,15 @@ By default this is
 Set the title bar color to
 .Ar COLOR ","
 which may be one of
-.Li BLACK ","
-.Li RED ","
-.Li GREEN ","
-.Li YELLOW ","
-.Li BLUE ","
-.Li MAGENTA ","
-.Li CYAN ","
+.Li black ","
+.Li red ","
+.Li green ","
+.Li yellow ","
+.Li blue ","
+.Li magenta ","
+.Li cyan ","
 or
-.Li WHITE
+.Li white
 .Po
 the default
 .Pc "."


### PR DESCRIPTION
Color names to "-g" are accepted in lower-case only. Update the
man page to reflect that.