### PR TITLE
Use makefile variables in a more standard manner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,21 @@
 CC        ?= gcc
 CFLAGS    ?= -std=c99 -Wall -Wextra -pedantic -O3
+CPPFLAGS  ?=
+LDFLAGS   ?=
 FEATURES  ?= -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED
 HEADERS   ?=
-LIBPATH   ?=
 DESTDIR   ?= /usr/local
 MANDIR    ?= $(DESTDIR)/man/man1
 CURSESLIB ?= ncursesw
-LIBS      ?= -l$(CURSESLIB) -lutil
+LIBRARIES ?= -l$(CURSESLIB) -lutil
+
+CPPFLAGS  += $(FEATURES)
+LDFLAGS   += $(LIBRARIES)
 
 all: mtm
 
 mtm: vtparser.c mtm.c config.h
-	$(CC) $(CFLAGS) $(FEATURES) -o $@ $(HEADERS) vtparser.c mtm.c $(LIBPATH) $(LIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $@ $(HEADERS) vtparser.c mtm.c
 
 vtparser.c: vttable.c
 


### PR DESCRIPTION
In order to make mtm easier to compile on a variety of operating
systems, let's use more standard makefile flags:

- Use CFLAGS for compiler flags.
- Use CPPFLAGS for preprocessor flags.
- Use LDFLAGS for linker flags.
- Deprecate LIBS in favor of LIBRARIES. It is better to avoid the use of
  LIBS for custom values as it is often used to store information for
  the linker.
- Deprecate LIBPATH. Use LDFLAGS to specify directories to search for
  libraries.

This way, for example, mtm can be compiled on FreeBSD with the following
command:

    env CFLAGS="-I/usr/local/include -I/usr/local/include/ncurses" \
            LDFLAGS=-L/usr/local/lib \
            make clean all

Also, I did not touch the HEADERS variable as I do not understand its
purpose.