### PR TITLE
Makefile-alt with CURSESCFLAGS and CURSESLIBS options

### DIFF
--- a/Makefile-alt
+++ b/Makefile-alt
@@ -1,0 +1,32 @@
+CC           ?= gcc
+CFLAGS       ?= -std=c99 -Wall -Wextra -pedantic -Os
+CURSESCFLAGS ?=
+CURSESLIBS   ?= -lncursesw
+DESTDIR      ?= /usr/local
+MANDIR       ?= $(DESTDIR)/man/man1
+
+CFLAGS       := $(CFLAGS) $(CURSESCFLAGS)
+LIBS         := -lutil $(CURSESLIBS)
+FEATURES     := -D_POSIX_C_SOURCE=200809L -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED
+
+all: mtm
+
+mtm: vtparser.c mtm.c config.h
+	echo $(CC) $(CFLAGS) $(FEATURES) -o $@ vtparser.c mtm.c $(LIBS)
+	$(CC) $(CFLAGS) $(FEATURES) -o $@ vtparser.c mtm.c $(LIBS)
+	strip -s mtm
+
+config.h: config.def.h
+	cp -i config.def.h config.h
+
+install: mtm
+	mkdir -p $(DESTDIR)/bin
+	mkdir -p $(MANDIR)
+	cp mtm $(DESTDIR)/bin
+	cp mtm.1 $(MANDIR)
+
+install-terminfo: mtm.ti
+	tic -s -x mtm.ti
+
+clean:
+	rm -f *.o mtm


### PR DESCRIPTION
An additional and alternate Makefile, better suited to people using `pkg-config` for their `ncursesw` library (the one on my Ubuntu 16.04 32bits is obsolete, it is still v5 while MTM expects v6). I could have added an invocation to `pkg-config` directly in the Makefile, but it makes it more general if it just uses two `CURSESCFLAGS` and `CURSESLIBS` options which can freely be set on invocation. 

Example usage:

    make CURSESCFLAGS="$(pkg-config --cflags ncursesw)" \
       CURSESLIBS="$(pkg-config --libs ncursesw)"

Note `CURSESLIBS` is not always just a matter of paths, it may be a matter of linker options. Ex for me, what `pkg-config` says about `ncursesw`, is:

    $ pkg-config --cflags ncursesw
    > -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -I/home/…/apps/ncurses/include/ncursesw -I/home/…/apps/ncurses/include
    $ pkg-config --libs ncursesw
    > -L/home/…/apps/ncurses/lib -Wl,-rpath,/home/…/apps/ncurses/lib -lncursesw

Note the `-Wl,-rpath …` part, which is why a library path is not always enough. For a custom ncurses library, an `-I…` option is also required for the C compilation.

This is why I’m proposing an additional and alternate Makefile, with `CURSESCFLAGS` and `CURSESLIBS` options.