### PR TITLE
docs: fix simple typo, princples -> principles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Introduction
 
 mtm is the Micro Terminal Multiplexer, a terminal multiplexer.
 
-It has four major features/princples:
+It has four major features/principles:
 
 Simplicity
     There are only a few commands, two of which are hardly ever used.


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `principles` rather than `princples`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md