### PR TITLE
docs: add another `make` invocation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,10 @@ Installation and configuration is fairly simple:
 
     make CURSESLIB=curses
 
+  or::
+
+    make HEADERS='-DNCURSESW_INCLUDE_H="<ncurses.h>"'
+
   whichever works for you.
 - Run `make install` if desired.
 


### PR DESCRIPTION
Currently suggested make commands do not work on Arch Linux.

Add the one that works to the README.