### PR TITLE
Allow setting the escape key delay

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -20,6 +20,12 @@
 #define DEFAULT_TERMINAL "screen-bce"
 #define DEFAULT_256_COLOR_TERMINAL "screen-256color-bce"
 
+/* Sets how long (in milliseconds) mtm should wait for an escape sequence
+ * to follow after the escape key is pressed before sending it on to
+ * the focused virtual terminal.
+ */
+#define ESCAPE_TIME 500
+
 /* mtm supports a scrollback buffer, allowing users to scroll back
  * through the output history of a virtual terminal. The SCROLLBACK
  * knob controls how many lines are saved (minus however many are

--- a/mtm.c
+++ b/mtm.c
@@ -1149,6 +1149,7 @@ main(int argc, char **argv)
 
     if (!initscr())
         quit(EXIT_FAILURE, "could not initialize terminal");
+    ESCDELAY = ESCAPE_TIME;
     raw();
     noecho();
     nonl();


### PR DESCRIPTION
By default ncurses waits a full second after the escape key is pressed before returning it from wget_wch(), to see if the remainder of an escape sequence is present. This is quite painful when using programs inside mtm that use the escape key often (e.g. modal text editors like vim).

This PR exposes this delay as part of config.h.

`tmux` exposes this as the `escape-time` setting, while `screen` exposes this as `maptimeout`.

I have selected 500 ms as a default to match tmux, although in practice for local usage a setting of 5 ms or less is appropriate.