### PR TITLE
Use pkg-config to find curseslibs if possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DESTDIR   ?= /usr/local
 MANDIR    ?= $(DESTDIR)/share/man/man1
 
 CURSESLIB ?= ncursesw
-LIBSDEFAULT ?= -l$(CURSESLIB) -lutil
+LIBS ?= -l$(CURSESLIB) -lutil
 
 # Guess CURSESLIB and LIBS but prefer the user choices if possible
 NEWCURSES = "$(shell pkg-config --libs curses)"
@@ -37,8 +37,6 @@ endif
 
 ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
     LIBS := $(shell pkg-config --libs $(CURSESLIB))
-else ("","")
-	LIBS := $(LIBSDEFAULT)
 endif
 
 all: mtm

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ MANDIR    ?= $(DESTDIR)/share/man/man1
 CURSESLIB ?= ncursesw
 LIBS      ?= -l$(CURSESLIB) -lutil
 
+ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
+    LIBS := $(shell pkg-config --libs $(CURSESLIB))
+endif
+
 all: mtm
 
 mtm: vtparser.c mtm.c pair.c config.h

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,40 @@ HEADERS   ?=
 LIBPATH   ?=
 DESTDIR   ?= /usr/local
 MANDIR    ?= $(DESTDIR)/share/man/man1
+
 CURSESLIB ?= ncursesw
-LIBS      ?= -l$(CURSESLIB) -lutil
+LIBSDEFAULT ?= -l$(CURSESLIB) -lutil
+
+# Guess CURSESLIB and LIBS but prefer the user choices if possible
+NEWCURSES = "$(shell pkg-config --libs curses)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs cursesw)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs ncurses)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs ncursesw)"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
+
+NEWCURSES = "$(shell pkg-config --libs $(CURSESLIB))"
+ifeq ($(.SHELLSTATUS),0)
+	CURSESLIB = $(NEWCURSES)
+endif
 
 ifeq ("$(shell basename $(shell command -v pkg-config))", "pkg-config")
     LIBS := $(shell pkg-config --libs $(CURSESLIB))
+else ("","")
+	LIBS := $(LIBSDEFAULT)
 endif
 
 all: mtm


### PR DESCRIPTION
Find the libs for ncurses if the `pkg-config` command is available. Some view this as an opinionated change (since ncurses should fix it instead), but I think it is a good choice.