### PR TITLE
Add 'only' delete keybinding

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -56,6 +56,7 @@
 
 /* The delete terminal key. */
 #define DELETE_NODE KEY(L'w')
+#define ONLY_NODE KEY(L'q')
 
 /* The force redraw key. */
 #define REDRAW KEY(L'l')
@@ -193,3 +194,4 @@ static wchar_t CSET_GRAPH[] ={ /* Graphics Set One */
 };
 
 #endif
+

--- a/mtm.1
+++ b/mtm.1
@@ -85,6 +85,8 @@ or stack vertically
 the newly-created terminal will be focused.
 .It Em "w"
 Delete the currently focused terminal.
+.It Em "q"
+Delete all other terminals, except this one.
 .It Em "l"
 .Pq "the letter ell"
 Redraw the screen.

--- a/mtm.c
+++ b/mtm.c
@@ -894,6 +894,26 @@ deletenode(NODE *n) /* Delete a node. */
 }
 
 static void
+onlynode(NODE *n) /* Delete other nodes. */
+{
+    struct NODE *node = NULL;
+    int next = false;
+    if (n != focused)
+        focus(n);
+    while(true){
+        /* KLUDGE: should go to the "next" node instead. */
+        (next=false) || ((node=findnode(root, ABOVE(n))) && (next=true));
+        next         || ((node=findnode(root, BELOW(n))) && (next=true));
+        next         || ((node=findnode(root,  LEFT(n))) && (next=true));
+        next         || ((node=findnode(root, RIGHT(n))) && (next=true));
+        if(!next)
+            break;
+        deletenode(node);
+    }
+}
+
+
+static void
 reshapeview(NODE *n, int d, int ow) /* Reshape a view. */
 {
     int oy, ox;
@@ -1101,6 +1121,7 @@ handlechar(int r, int k) /* Handle a single input character. */
     DO(true,  HSPLIT,              split(n, HORIZONTAL))
     DO(true,  VSPLIT,              split(n, VERTICAL))
     DO(true,  DELETE_NODE,         deletenode(n))
+    DO(true,  ONLY_NODE,           onlynode(n))
     DO(true,  REDRAW,              touchwin(stdscr); draw(root); redrawwin(stdscr))
     DO(true,  SCROLLUP,            scrollback(n))
     DO(true,  SCROLLDOWN,          scrollforward(n))
@@ -1171,3 +1192,4 @@ main(int argc, char **argv)
     quit(EXIT_SUCCESS, NULL);
     return EXIT_SUCCESS; /* not reached */
 }
+


### PR DESCRIPTION
Deletes all the windows except this one, which I find very useful. Feel free to not include it.

On another note, I'd like to be able to provide optional patches somehow in a suckless-like way.