### PR TITLE
Add a bailout keybinding

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -57,6 +57,9 @@
 /* The delete terminal key. */
 #define DELETE_NODE KEY(L'w')
 
+/* does nothing, specifically */
+#define BAILOUT KEY(L'g')
+
 /* The force redraw key. */
 #define REDRAW KEY(L'l')
 
@@ -193,3 +196,4 @@ static wchar_t CSET_GRAPH[] ={ /* Graphics Set One */
 };
 
 #endif
+

--- a/config.def.h
+++ b/config.def.h
@@ -58,7 +58,7 @@
 #define DELETE_NODE KEY(L'w')
 
 /* does nothing, specifically */
-#define BAILOUT KEY(L'g')
+#define BAILOUT KEY(L'c')
 
 /* The force redraw key. */
 #define REDRAW KEY(L'l')

--- a/mtm.1
+++ b/mtm.1
@@ -74,7 +74,7 @@ when prefixed with the command character:
 .Bl -tag -width Ds
 .It Em "Up/Down/Right/Left Arrow"
 Select the terminal above/below/to the right of/to the left of the currently focused one.
-.It Em "g"
+.It Em "c"
 Abandon the keychord sequence.
 .It Em "o"
 .Pq "the letter oh"

--- a/mtm.1
+++ b/mtm.1
@@ -74,6 +74,8 @@ when prefixed with the command character:
 .Bl -tag -width Ds
 .It Em "Up/Down/Right/Left Arrow"
 Select the terminal above/below/to the right of/to the left of the currently focused one.
+.It Em "g"
+Abandon the keychord sequence.
 .It Em "o"
 .Pq "the letter oh"
 Switch to the last-focused terminal.

--- a/mtm.c
+++ b/mtm.c
@@ -894,6 +894,12 @@ deletenode(NODE *n) /* Delete a node. */
 }
 
 static void
+bailout(void) /* nothing to do */
+{
+    ;
+}
+
+static void
 reshapeview(NODE *n, int d, int ow) /* Reshape a view. */
 {
     int oy, ox;
@@ -1101,6 +1107,7 @@ handlechar(int r, int k) /* Handle a single input character. */
     DO(true,  HSPLIT,              split(n, HORIZONTAL))
     DO(true,  VSPLIT,              split(n, VERTICAL))
     DO(true,  DELETE_NODE,         deletenode(n))
+    DO(true,  BAILOUT,             bailout())
     DO(true,  REDRAW,              touchwin(stdscr); draw(root); redrawwin(stdscr))
     DO(true,  SCROLLUP,            scrollback(n))
     DO(true,  SCROLLDOWN,          scrollforward(n))
@@ -1171,3 +1178,4 @@ main(int argc, char **argv)
     quit(EXIT_SUCCESS, NULL);
     return EXIT_SUCCESS; /* not reached */
 }
+


### PR DESCRIPTION
So you can silently quit the keybinding. The obvious thing to do is set
it to the same as the original "g", so mashing g twice quits the entry.
Another good choice could be escape.