### PR TITLE
Use g as the bailout key thanks to the fact that it isn't c-g

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -64,7 +64,7 @@
 #define DELETE_NODE KEY(L'w')
 
 /* does nothing, specifically */
-#define BAILOUT KEY(L'c')
+#define BAILOUT KEY(L'g')
 
 /* clears the scrollback and everything */
 #define NUKE KEY(L'k')

--- a/mtm.1
+++ b/mtm.1
@@ -54,7 +54,7 @@ key.
 By default this is
 .Dq "g" "."
 Note that this default can be changed at compile time,
-and thus may differ in your installation.
+and thus may differ in your installation. Press it twice to cancel.
 .El
 .Pp
 .Ss Usage
@@ -74,7 +74,7 @@ when prefixed with the command character:
 .Bl -tag -width Ds
 .It Em "Up/Down/Right/Left Arrow"
 Select the terminal above/below/to the right of/to the left of the currently focused one.
-.It Em "c"
+.It Em "g"
 Abandon the keychord sequence.
 .It Em "o"
 .Pq "the letter oh"


### PR DESCRIPTION
Keep it simple. Mash it thrice to really shove a g down there.

You can still send ctrl-g with `ctrl-g ctrl-g` because the bailout key is merely `g`.
smashed -- submitted
`c-g g` -- nothing
`c-g c-g` -- `c-g`
On the other hand, maybe it's better to make the bailout key actuate on control too?