### PR TITLE
Document NUKE. Scroll to the bottom so the cursor is always visible afterward.

### DIFF
--- a/mtm.1
+++ b/mtm.1
@@ -100,6 +100,8 @@ Note that if the screen is currently scrolled back
 these keys need not be prefixed with the command key.
 .Nm
 will also scroll to the bottom on user input.
+.It Em "k"
+Clear the screen and the scrolling history. Scroll to the bottom.
 .El
 .Pp
 Note that these command keys can be changed at compile time,

--- a/mtm.c
+++ b/mtm.c
@@ -1102,7 +1102,7 @@ handlechar(int r, int k) /* Handle a single input character. */
     DO(true,  VSPLIT,              split(n, VERTICAL))
     DO(true,  DELETE_NODE,         deletenode(n))
     DO(true,  BAILOUT,             (void)1)
-    DO(true,  NUKE,                wclear(n->s->win))
+    DO(true,  NUKE,                wclear(n->s->win); SB)
     DO(true,  REDRAW,              touchwin(stdscr); draw(root); redrawwin(stdscr))
     DO(true,  SCROLLUP,            scrollback(n))
     DO(true,  SCROLLDOWN,          scrollforward(n))


### PR DESCRIPTION
Add an item for `k` in `mtm.1`, including the scroll to the bottom described below.

In `mtm.c`: With the existing code, if you scroll back and then type `Ctrl-G k`, you are still scrolled back, looking at an empty history with no visible cursor. But if you scroll to the end and then type `Ctrl-G k`, you see an empty window including the cursor. That makes more sense to me.

With this change, you always see an empty window including the cursor.